### PR TITLE
fixes #3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+[0.3.1] - 2024-10-17
+--------------------
+
+Fixed
+~~~~~
+* None valued ids on bulk add handling
+
+
 [0.3.0] - 2023-07-10
 --------------------
 

--- a/atomic_operations/__init__.py
+++ b/atomic_operations/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 VERSION = __version__  # synonym

--- a/atomic_operations/views.py
+++ b/atomic_operations/views.py
@@ -109,10 +109,11 @@ class AtomicOperationView(APIView):
             _serializer.is_valid(raise_exception=True)
             instance = model_class(**_serializer.validated_data)
             objs.append(instance)
-            self.response_data.append(
-                _serializer.__class__(instance=instance).data)
         model_class.objects.bulk_create(
             objs)
+        # append serialized data after save has successfully called. Otherwise id could be None. See #3
+        self.response_data.extend(
+            [_serializer.__class__(instance=obj).data for obj in objs])
 
     def perform_bulk_delete(self, bulk_operation_data):
         obj_ids = []

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -195,7 +195,7 @@ class TestAtomicOperationView(TestCase):
 
         self.assertEqual(RelatedModel.objects.get(pk=1),
                          BasicModel.objects.get(pk=2).to_one)
-        self.assertQuerysetEqual(RelatedModelTwo.objects.filter(pk__in=[1, 2]),
+        self.assertQuerySetEqual(RelatedModelTwo.objects.filter(pk__in=[1, 2]),
                                  BasicModel.objects.get(pk=2).to_many.all())
 
     def test_bulk_view_processing_with_valid_request(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,6 @@
 import json
 
+from django import VERSION
 from django.test import Client, RequestFactory, TestCase
 
 from atomic_operations.consts import (
@@ -195,8 +196,15 @@ class TestAtomicOperationView(TestCase):
 
         self.assertEqual(RelatedModel.objects.get(pk=1),
                          BasicModel.objects.get(pk=2).to_one)
-        self.assertQuerySetEqual(RelatedModelTwo.objects.filter(pk__in=[1, 2]),
-                                 BasicModel.objects.get(pk=2).to_many.all())
+
+        major, minor, _, _, _ = VERSION
+        if int(major) <= 4 and int(minor) <= 1:
+            self.assertQuerysetEqual(RelatedModelTwo.objects.filter(pk__in=[1, 2]),
+                                     BasicModel.objects.get(pk=2).to_many.all())
+        else:
+            # with django 4.2 TransactionTestCase.assertQuerysetEqual() is deprecated in favor of assertQuerySetEqual().
+            self.assertQuerySetEqual(RelatedModelTwo.objects.filter(pk__in=[1, 2]),
+                                     BasicModel.objects.get(pk=2).to_many.all())
 
     def test_bulk_view_processing_with_valid_request(self):
         operations = [


### PR DESCRIPTION
* appends serialized data on bulk add after calling bulk operation. Otherwise the id is not present inside the serialized data.

# fixes 3 