### PR TITLE
fix: incorrect media type

### DIFF
--- a/atomic_operations/consts.py
+++ b/atomic_operations/consts.py
@@ -1,4 +1,4 @@
 ATOMIC_OPERATIONS = "atomic:operations"
 ATOMIC_RESULTS = "atomic:results"
-ATOMIC_MEDIA_TYPE = 'vnd.api+json;ext="https://jsonapi.org/ext/atomic'
+ATOMIC_MEDIA_TYPE = 'vnd.api+json;ext="https://jsonapi.org/ext/atomic"'
 ATOMIC_CONTENT_TYPE = f'application/{ATOMIC_MEDIA_TYPE}'

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -21,6 +21,29 @@ class TestAtomicOperationView(TestCase):
 
         self.maxDiff = None
 
+    def test_content_type_extension(self):
+        """Test that the correct content type is accepted
+        
+        The media type and parameters are defined at https://jsonapi.org/ext/atomic. This tests
+        hardcodes the value to separate the test from the library's constants.
+        
+        """
+        operations = []
+
+        data = {
+            ATOMIC_OPERATIONS: operations
+        }
+
+        response = self.client.post(
+            path="/",
+            data=data,
+            content_type='application/vnd.api+json; ext="https://jsonapi.org/ext/atomic"',
+
+            **{"HTTP_ACCEPT": 'application/vnd.api+json; ext="https://jsonapi.org/ext/atomic"'}
+        )
+
+        self.assertNotEqual(406, response.status_code)  # 406 Not Acceptable
+
     def test_view_processing_with_valid_request(self):
         operations = [
             {


### PR DESCRIPTION
Fixes the content type that the library expects in the `accept` header.

I took a stab at a unit test for this but I'm not sure it's valuable, we could take or leave it.

NOTE: This doesn't address wild card behavior or add to the docs as [the issue](https://github.com/encode/django-rest-framework/discussions/9564) is still open. So this PR may not close the related issue.

related #2